### PR TITLE
allow same name for station and survey

### DIFF
--- a/src/readval.c
+++ b/src/readval.c
@@ -296,16 +296,6 @@ anon_wall_station:
 	 if (TSTBIT(pcs->infer, INFER_EXPORTS)) ptr->min_export = USHRT_MAX;
       }
    } else {
-      /* check that the same name isn't being used for a survey and station */
-      if (fSurvey ^ TSTBIT(ptr->sflags, SFLAGS_SURVEY)) {
-	 /* TRANSLATORS: Here "station" is a survey station, not a train station.
-	  *
-	  * Here "survey" is a "cave map" rather than list of questions - it should be
-	  * translated to the terminology that cavers using the language would use.
-	  */
-	 compile_diagnostic(DIAG_ERR, /*“%s” can’t be both a station and a survey*/27,
-			    sprint_prefix(ptr));
-      }
       if (!fSurvey && TSTBIT(pcs->infer, INFER_EXPORTS)) ptr->min_export = USHRT_MAX;
    }
 

--- a/tests/cavern.tst
+++ b/tests/cavern.tst
@@ -48,7 +48,6 @@ testdir=`(cd "$testdir" && pwd)`
  exporterr1 exporterr2 exporterr3 exporterr4 exporterr5\
  exporterr1b exporterr2b exporterr3b exporterr6 exporterr6b\
  hanging_cpt badinc badinc2 badinc3 badinc4 nonexistent_file ONELEG\
- stnsurvey1 stnsurvey2\
  tapelessthandepth longname chinabug chinabug2\
  multinormal multinormignall multidiving multicylpolar multicartesian\
  multinosurv multinormalbad multibug\


### PR DESCRIPTION
Current survex allows the same name for a station and a survex using this syntax:
```
; no warnings
1       2       1.0     0.0     0.0
2       2.1     1.0     90.0    0.0
2.1     2.2     1.0     180.0   0.0
```
However, this syntax throws an error:
```
; error: "2" can't be both a station and a survey
1	2	1.0	0.0	0.0
2	2.1	1.0	90.0	0.0
*begin 2
1	2	1.0	180.0	0.0
*end 2
```
This PR allows the second syntax, both examples look the same in Aven.