### PR TITLE
suppress "Separator in survey name" warning

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -691,7 +691,7 @@ cmd_begin(void)
       filepos fp;
       prefix *survey;
       get_pos(&fp);
-      survey = read_prefix(PFX_SURVEY|PFX_ALLOW_ROOT|PFX_WARN_SEPARATOR);
+      survey = read_prefix(PFX_SURVEY|PFX_ALLOW_ROOT);
       pcs->begin_survey = survey;
       pcs->Prefix = survey;
       check_reentry(survey, &fp);

--- a/tests/cavern.tst
+++ b/tests/cavern.tst
@@ -59,7 +59,7 @@ testdir=`(cd "$testdir" && pwd)`
  omitclino back back2 bad_back\
  notentranceorexport inferunknown inferexports bad_units_factor\
  bad_units_qlist\
- percent_gradient dotinsurvey leandroclino lowsd revdir gettokennullderef\
+ percent_gradient leandroclino lowsd revdir gettokennullderef\
  nosurveyhanging cmd_solve_nothing cmd_solve_nothing_implicit\
  cmd_calibrate cmd_declination cmd_declination_auto cmd_declination_conv\
  lech level 2fixbug dot17 3dcorner\


### PR DESCRIPTION
Current survex allows introducing survey name "a.b" implicitly and then entering "a" and "b" one after the other without any warnings:
```
; no warnings
1       2       1.0     0.0     0.0
2       a.b.1   1.0     90.0    0.0
*begin a
*begin b
1       2       1.0     180.0   0.0
*end b
*end a
```
However, entering "a.b" directly gives a warning:
```
; warning: Separator in survey name
1       2       1.0     0.0     0.0
2       a.b.1   1.0     90.0    0.0
*begin a.b
1       2       1.0     180.0   0.0
*end a.b
```
I see no reason why syntax 2 should be discouraged. This PR suppresses the warning.