### PR TITLE
Update survex.spec.in

### DIFF
--- a/survex.spec.in
+++ b/survex.spec.in
@@ -13,7 +13,8 @@ Packager: Olly Betts <olly@survex.com>
 # dependencies instead:
 #BuildRequires: wxGTK-devel >= 2.8.0, proj-devel
 #Requires: wxGTK >= 2.8.0, proj, proj-epsg
-BuildRequires: wxGTK3-devel, proj-devel
+# Fedora have removed gcc from the default build environment so explicitly list it here
+BuildRequires: wxGTK3-devel, proj-devel, gcc-g++
 Requires: wxGTK3, proj, proj-epsg
 BuildRoot: %{_tmppath}/%{name}-buildroot
 


### PR DESCRIPTION
Fedora have removed gcc from the default build environment so need to explicitly list it in the BuildRequires tag.
See https://fedoraproject.org/wiki/Changes/Remove_GCC_from_BuildRoot for more information.