### PR TITLE
Fix img_open_survey for !defined(IMG_HOSTED)

### DIFF
--- a/src/img.c
+++ b/src/img.c
@@ -421,7 +421,8 @@ img_open_survey(const char *fnm, const char *survey)
    }
 
    fh = fopenWithPthAndExt("", fnm, EXT_SVX_3D, "rb", &filename_opened);
-   pimg = img_read_stream_survey(fh, fclose, filename_opened, survey);
+   pimg = img_read_stream_survey(fh, fclose,
+       filename_opened ? filename_opened : fnm, survey);
    if (pimg) {
        pimg->filename_opened = filename_opened;
    } else {


### PR DESCRIPTION
Fix a segmentation fault in `img_open_survey` when using `img.c` as a library outside of survex.