### PR TITLE
Report range (N-S, E-W) without anonymous stations

### DIFF
--- a/src/cavern.c
+++ b/src/cavern.c
@@ -76,8 +76,8 @@ static bool f_warnings_are_errors = fFalse; /* turn warnings into errors */
 nosurveylink *nosurveyhead;
 
 real totadj, total, totplan, totvert;
-real min[3], max[3];
-prefix *pfxHi[3], *pfxLo[3];
+real min[6], max[6];
+prefix *pfxHi[6], *pfxLo[6];
 
 char *survey_title = NULL;
 int survey_title_len;
@@ -204,7 +204,10 @@ main(int argc, char **argv)
    for (d = 0; d <= 2; d++) {
       min[d] = HUGE_REAL;
       max[d] = -HUGE_REAL;
+      min[d + 3] = HUGE_REAL;
+      max[d + 3] = -HUGE_REAL;
       pfxHi[d] = pfxLo[d] = NULL;
+      pfxHi[d + 3] = pfxLo[d + 3] = NULL;
    }
 
    /* at least one argument must be given */
@@ -405,6 +408,11 @@ do_range(int d, int msgno, real length_factor, const char * units)
    printf(msg(msgno), hi - lo, units, pfx_hi, hi, units, pfx_lo, lo, units);
    osfree(pfx_hi);
    putnl();
+
+   // Range without anonymous stations at offset 3
+   if (d < 3 && (pfxHi[d] != pfxHi[d + 3] || pfxLo[d] != pfxLo[d + 3])) {
+      do_range(d + 3, msgno, length_factor, units);
+   }
 }
 
 static void

--- a/src/cavern.h
+++ b/src/cavern.h
@@ -363,8 +363,8 @@ extern long cLegs, cStns, cComponents;
 extern FILE *fhErrStat;
 extern img *pimg;
 extern real totadj, total, totplan, totvert;
-extern real min[3], max[3];
-extern prefix *pfxHi[3], *pfxLo[3];
+extern real min[6], max[6];
+extern prefix *pfxHi[6], *pfxLo[6];
 extern bool fQuiet; /* just show brief summary + errors */
 extern bool fMute; /* just show errors */
 extern bool fSuppress; /* only output 3d file */

--- a/src/netskel.c
+++ b/src/netskel.c
@@ -939,6 +939,20 @@ replace_trailing_travs(void)
 	       pfxHi[d] = stn1->name;
 	    }
 	 }
+
+	 // Range without anonymous stations at offset 3
+	 if (!TSTBIT(stn1->name->sflags, SFLAGS_ANON)) {
+	    for (d = 0; d < 3; d++) {
+	       if (POS(stn1, d) < min[d + 3]) {
+		  min[d + 3] = POS(stn1, d);
+		  pfxLo[d + 3] = stn1->name;
+	       }
+	       if (POS(stn1, d) > max[d + 3]) {
+		  max[d + 3] = POS(stn1, d);
+		  pfxHi[d + 3] = stn1->name;
+	       }
+	    }
+	 }
       }
 
       d = stn1->name->shape;


### PR DESCRIPTION
We are interested in seeing the North-South and East-West ranges without anonymous stations. This simple patch adds this to the log. The extra lines are only printed if one of the extreme points is an anonymous station.

Example output:
```
Vertical range = 1176.88m (from casino.3_1 at 1931.82m to 115.115rest.orgasm.1 at 754.93m)
North-South range = 6234.36m (from anonymous station at 5285824.65m to rentner.1_14_45.23 at 5279590
North-South range = 6229.52m (from huebel.3.4 at 5285819.81m to rentner.1_14_45.23 at 5279590.29m)
East-West range = 2370.76m (from casino.9_14 at 412126.18m to anonymous station at 409755.42m)
East-West range = 2368.30m (from casino.9_14 at 412126.18m to rentner.1_14_45_16.1 at 409757.88m)
```