### PR TITLE
add dxf splay layer

### DIFF
--- a/doc/survexport.sgml
+++ b/doc/survexport.sgml
@@ -19,8 +19,49 @@ to another format.
 </cmdsynopsis>
 </refsynopsisdiv>
   
+<refsect1><title>Options</title>
+
+<para><option>-s, --survey=SURVEY</option> only load the sub-survey with this prefix</para>
+<para><option>--scale=SCALE</option> scale (50, 0.02, 1:50 and 2:100 all mean 1:50)</para>
+<para><option>--bearing=BEARING</option> bearing (90, 90d, 100g all mean 90°)</para>
+<para><option>--tilt=TILT</option> tilt (45, 45d, 50g, 100% all mean 45°)</para>
+<para><option>--plan	</option> plan view (equivalent to --tilt=-90)</para>
+<para><option>--elevation</option> elevation view (equivalent to --tilt=0)</para>
+<para><option>--legs	</option> underground survey legs</para>
+<para><option>--surface-legs</option> surface survey legs</para>
+<para><option>--splays	</option> splay legs</para>
+<para><option>--crosses	</option> station markers</para>
+<para><option>--station-names	</option> station labels</para>
+<para><option>--entrances	</option> entrances</para>
+<para><option>--fixes	</option>		fixed points</para>
+<para><option>--exports</option> exported stations</para>
+<para><option>--cross-sections</option> cross-sections</para>
+<para><option>--walls		</option> walls</para>
+<para><option>--passages	</option> passages</para>
+<para><option>--origin-in-centre</option> origin in centre</para>
+<para><option>--full-coordinates</option> full coordinates</para>
+<para><option>--clamp-to-ground</option> clamp to ground</para>
+<para><option>--defaults</option> include items exported by default</para>
+<para><option>-g, --grid[=GRID]</option> generate grid (default 100m)</para>
+<para><option>-t, --text-height=TEXT-HEIGHT</option> station labels text height (default 0.6)</para>
+<para><option>-m, --marker-size=MARKER-SIZE</option> station marker size (default 0.8)</para>
+<para><option>--csv	</option> produce CSV output</para>
+<para><option>--dxf	</option> produce DXF output</para>
+<para><option>--eps	</option> produce EPS output</para>
+<para><option>--gpx	</option> produce GPX output</para>
+<para><option>--hpgl	</option> produce HPGL output</para>
+<para><option>--json	</option> produce JSON output</para>
+<para><option>--kml	</option> produce KML output</para>
+<para><option>--plt	</option> produce Compass PLT output for Carto</para>
+<para><option>--skencil</option> produce Skencil output</para>
+<para><option>--pos</option> produce Survex POS output</para>
+<para><option>--svg</option> produce SVG output</para>
+<para><option>--help</option> display short help and exit</para>
+<para><option>--version</option> output version information and exit</para>
+
+</refsect1>
+
 <refsect1><title>Description</title>
-<!-- FIXME: more info (opts, etc) -->
 
 <para>
 The input formats supports are all those supported by Survex's "img"
@@ -59,6 +100,16 @@ number part first, so you'd get:
 040.sv11
 40_entrance_tag
 40b_entrance_tag</screen>
+</refsect2>
+
+<refsect2><title>DXF Export</title>
+
+<para>
+DXF export seperates Splays, Surface legs, Surface points, survey legs,
+and survey stations onto separate layers. Splays will export dotted, and surface
+legs dashed. This is not configurable.
+</para>
+
 </refsect2>
 
 </refsect1>

--- a/src/export.cc
+++ b/src/export.cc
@@ -346,23 +346,23 @@ DXF::header(const char *, const char *, time_t,
 void
 DXF::line(const img_point *p1, const img_point *p, unsigned flags, bool fPendingMove)
 {
-   bool fSurface = (flags & SURF);
-   bool fSplay = (flags & SPLAYS);
-   (void)fPendingMove; /* unused */
-   fprintf(fh, "0\nLINE\n");
-   if (fSurface) { /* select layer */
-      fprintf(fh, "8\nSurface\n" );
-   } else if (fSplay) {
-      fprintf(fh, "8\nSplays\n");
-   } else {
-      fprintf(fh, "8\nCentreLine\n");
-   }
-   fprintf(fh, "10\n%6.2f\n", p1->x);
-   fprintf(fh, "20\n%6.2f\n", p1->y);
-   fprintf(fh, "30\n%6.2f\n", p1->z);
-   fprintf(fh, "11\n%6.2f\n", p->x);
-   fprintf(fh, "21\n%6.2f\n", p->y);
-   fprintf(fh, "31\n%6.2f\n", p->z);
+    bool fSurface = (flags & SURF);
+    bool fSplay = (flags & SPLAYS);
+    (void)fPendingMove; /* unused */
+    fprintf(fh, "0\nLINE\n");
+    if (fSurface) { /* select layer */
+	fprintf(fh, "8\nSurface\n" );
+    } else if (fSplay) {
+	fprintf(fh, "8\nSplays\n");
+    } else {
+	fprintf(fh, "8\nCentreLine\n");
+    }
+    fprintf(fh, "10\n%6.2f\n", p1->x);
+    fprintf(fh, "20\n%6.2f\n", p1->y);
+    fprintf(fh, "30\n%6.2f\n", p1->z);
+    fprintf(fh, "11\n%6.2f\n", p->x);
+    fprintf(fh, "21\n%6.2f\n", p->y);
+    fprintf(fh, "31\n%6.2f\n", p->z);
 }
 
 void

--- a/src/export.cc
+++ b/src/export.cc
@@ -251,6 +251,15 @@ DXF::header(const char *, const char *, time_t,
 	       "40\n2.5\n"
 	       "49\n1.25\n"
 	       "49\n-1.25\n"
+	       "0\nLTYPE\n" /* define DOT line type */
+	       "2\nDOT\n"
+	       "70\n64\n"
+	       "3\nDotted\n"
+	       "72\n65\n"
+	       "73\n2\n"
+	       "40\n1\n"
+	       "49\n0\n"
+	       "49\n1\n"
 	       "0\nENDTAB\n");
    fprintf(fh, "0\nTABLE\n"
 	       "2\nLAYER\n");
@@ -285,6 +294,11 @@ DXF::header(const char *, const char *, time_t,
    fprintf(fh, "70\n64\n"); /* shows layer is referenced by entities */
    fprintf(fh, "62\n7\n"); /* color */
    fprintf(fh, "6\nCONTINUOUS\n"); /* linetype */
+   /* Next Layer: Splays */
+   fprintf(fh, "0\nLAYER\n2\nSplays\n");
+   fprintf(fh, "70\n64\n"); /* shows layer is referenced by entities */
+   fprintf(fh, "62\n5\n"); /* color */
+   fprintf(fh, "6\nDOT\n"); /* linetype;  */
    if (grid > 0) {
       /* Next Layer: Grid */
       fprintf(fh, "0\nLAYER\n2\nGrid\n");
@@ -336,10 +350,10 @@ DXF::line(const img_point *p1, const img_point *p, unsigned flags, bool fPending
    bool fSplay = (flags & SPLAYS);
    (void)fPendingMove; /* unused */
    fprintf(fh, "0\nLINE\n");
-   if fSurface { /* select layer */
+   if (fSurface) { /* select layer */
       fprintf(fh, "8\nSurface\n" );
-   } else if fSplay {
-      fprintf(fh, "8\nSplay\n");
+   } else if (fSplay) {
+      fprintf(fh, "8\nSplays\n");
    } else {
       fprintf(fh, "8\nCentreLine\n");
    }

--- a/src/export.cc
+++ b/src/export.cc
@@ -333,9 +333,16 @@ void
 DXF::line(const img_point *p1, const img_point *p, unsigned flags, bool fPendingMove)
 {
    bool fSurface = (flags & SURF);
+   bool fSplay = (flags & SPLAYS);
    (void)fPendingMove; /* unused */
    fprintf(fh, "0\nLINE\n");
-   fprintf(fh, fSurface ? "8\nSurface\n" : "8\nCentreLine\n"); /* Layer */
+   if fSurface { /* select layer */
+      fprintf(fh, "8\nSurface\n" );
+   } else if fSplay {
+      fprintf(fh, "8\nSplay\n");
+   } else {
+      fprintf(fh, "8\nCentreLine\n");
+   }
    fprintf(fh, "10\n%6.2f\n", p1->x);
    fprintf(fh, "20\n%6.2f\n", p1->y);
    fprintf(fh, "30\n%6.2f\n", p1->z);

--- a/tests/surfequate.dxf
+++ b/tests/surfequate.dxf
@@ -206,6 +206,102 @@ Surface
   2.90
 31
   0.77
+0
+TEXT
+8
+SurfaceLabels
+10
+  1.94
+20
+  2.90
+30
+  0.77
+40
+  0.60
+1
+b.3
+0
+POINT
+8
+SurfaceStations
+10
+  1.94
+20
+  2.90
+30
+  0.77
+0
+TEXT
+8
+SurfaceLabels
+10
+  0.00
+20
+  0.74
+30
+  0.00
+40
+  0.60
+1
+b.2
+0
+POINT
+8
+SurfaceStations
+10
+  0.00
+20
+  0.74
+30
+  0.00
+0
+TEXT
+8
+SurfaceLabels
+10
+  0.00
+20
+  0.74
+30
+  0.00
+40
+  0.60
+1
+a.2
+0
+POINT
+8
+SurfaceStations
+10
+  0.00
+20
+  0.74
+30
+  0.00
+0
+TEXT
+8
+SurfaceLabels
+10
+  8.51
+20
+  0.00
+30
+  4.16
+40
+  0.60
+1
+a.1
+0
+POINT
+8
+SurfaceStations
+10
+  8.51
+20
+  0.00
+30
+  4.16
 000
 ENDSEC
 000

--- a/tests/surfequate.dxf
+++ b/tests/surfequate.dxf
@@ -71,6 +71,24 @@ Dashed
 49
 -1.25
 0
+LTYPE
+2
+DOT
+70
+64
+3
+Dotted
+72
+65
+73
+2
+40
+1
+49
+0
+49
+1
+0
 ENDTAB
 0
 TABLE
@@ -139,6 +157,16 @@ SurfaceLabels
 6
 CONTINUOUS
 0
+LAYER
+2
+Splays
+70
+64
+62
+5
+6
+DOT
+0
 ENDTAB
 0
 ENDSEC
@@ -178,102 +206,6 @@ Surface
   2.90
 31
   0.77
-0
-TEXT
-8
-SurfaceLabels
-10
-  1.94
-20
-  2.90
-30
-  0.77
-40
-  0.60
-1
-b.3
-0
-POINT
-8
-SurfaceStations
-10
-  1.94
-20
-  2.90
-30
-  0.77
-0
-TEXT
-8
-SurfaceLabels
-10
-  0.00
-20
-  0.74
-30
-  0.00
-40
-  0.60
-1
-b.2
-0
-POINT
-8
-SurfaceStations
-10
-  0.00
-20
-  0.74
-30
-  0.00
-0
-TEXT
-8
-SurfaceLabels
-10
-  0.00
-20
-  0.74
-30
-  0.00
-40
-  0.60
-1
-a.2
-0
-POINT
-8
-SurfaceStations
-10
-  0.00
-20
-  0.74
-30
-  0.00
-0
-TEXT
-8
-SurfaceLabels
-10
-  8.51
-20
-  0.00
-30
-  4.16
-40
-  0.60
-1
-a.1
-0
-POINT
-8
-SurfaceStations
-10
-  8.51
-20
-  0.00
-30
-  4.16
 000
 ENDSEC
 000


### PR DESCRIPTION
This puts splays on a seperate layer in the DXF generated by `survexport`, per conversations on irc.

Basic documentation of survexport, including this change is added.

`DXF::line` is modified to `ts=8 sw=4`; no other whitespace changes in the codebase.

For future reference: https://images.autodesk.com/adsk/files/autocad_2012_pdf_dxf-reference_enu.pdf is the official documentation for DXF from autodesk.