### PR TITLE
img_read_stream_survey: use separator

### DIFF
--- a/src/img.c
+++ b/src/img.c
@@ -560,7 +560,8 @@ stn_included(img *pimg)
     if (!pimg->survey_len) return 1;
     size_t l = pimg->survey_len;
     const char *s = pimg->label_buf;
-    if (strncmp(pimg->survey, s, l + 1) != 0) {
+    if (strncmp(pimg->survey, s, l) != 0 ||
+        s[l] != pimg->separator) {
 	return 0;
     }
     pimg->label += l + 1;
@@ -575,7 +576,7 @@ survey_included(img *pimg)
     size_t l = pimg->survey_len;
     const char *s = pimg->label_buf;
     if (strncmp(pimg->survey, s, l) != 0 ||
-	!(s[l] == '.' || s[l] == '\0')) {
+	!(s[l] == pimg->separator || s[l] == '\0')) {
        return 0;
     }
     pimg->label += l;
@@ -1167,6 +1168,7 @@ img_read_stream_survey(FILE *stream, int (*close_func)(FILE*),
    if (survey) {
       len = strlen(survey);
       if (len) {
+	 // TODO pimg->separator not known yet
 	 if (survey[len - 1] == '.') len--;
 	 if (len) {
 	    char *p;


### PR DESCRIPTION
Use `pimg->separator` with survey filtering in `img_read_stream_survey`.

Example:
```
*set separator /
*set names .
*begin foo
  *begin bar
    1 2 10 0 0
    2 3 5 90 0
  *end bar
*end foo
```
```sh
dump3d data.3d --survey=foo
```
Without this patch:
```
TITLE "foo"
DATE "@1728209233"
DATE_NUMERIC 1728209233
VERSION 8
SEPARATOR '/'
--
MOVE 0.00 0.00 0.00
STOP
```
With this patch:
```
TITLE "foo"
DATE "@1728209233"
DATE_NUMERIC 1728209233
VERSION 8
SEPARATOR '/'
--
MOVE 0.00 0.00 0.00
LINE 0.00 10.00 0.00 [bar] STYLE=NORMAL
LINE 5.00 10.00 0.00 [bar] STYLE=NORMAL
NODE 5.00 10.00 0.00 [bar/3] UNDERGROUND
NODE 0.00 10.00 0.00 [bar/2] UNDERGROUND
NODE 0.00 0.00 0.00 [bar/1] UNDERGROUND
STOP
```